### PR TITLE
[FEAT] Introduce isTargetInstanceOf method

### DIFF
--- a/src/veil.js
+++ b/src/veil.js
@@ -67,6 +67,12 @@ class Veil {
   #pierce() {
     this.#pierced = true;
   };
+
+  isTargetInstanceOf(obj) {
+    return typeof obj === 'function'
+      ? this.#target instanceof obj
+      : Object.getPrototypeOf(obj) === this.#targetProto
+  };
 };
 
 export default Veil;

--- a/tests/test-cases/1.test.js
+++ b/tests/test-cases/1.test.js
@@ -11,12 +11,45 @@ var project = new Project('123');
 var veiledProject = new Veil(project, mockPresetsData);
 
 describe('Veiled object', function () {
-  it('If non pierced: calling preseted target object methods invokes presets data', function () {
-    assert.equal(veiledProject.name(), mockPresetsData.name);
-    assert.equal(veiledProject.author(), mockPresetsData.author);
-  });
-  it('If pierced: calling non-preseted target object methods pierces the veil and invokes native target methods', function () {
-    assert.equal(veiledProject.description(), 'description');
-    assert.equal(veiledProject.name(), project.name());
-  });
+  it(
+    'If non pierced: calling preseted target object methods invokes presets data',
+    function () {
+      assert.equal(
+        veiledProject.name(),
+        mockPresetsData.name
+      );
+      assert.equal(
+        veiledProject.author(),
+        mockPresetsData.author
+      );
+    }
+  );
+
+  it(
+    'If pierced: calling non-preseted target object methods pierces the veil and invokes native target methods',
+    function () {
+      assert.equal(
+        veiledProject.description(),
+        'description'
+      );
+      assert.equal(
+        veiledProject.name(),
+        project.name()
+      );
+    }
+  );
+
+  it(
+    'The target object is an instance of a origin object or class',
+    function () {
+      assert.equal(
+        veiledProject.isTargetInstanceOf(project),
+        true
+      );
+      assert.equal(
+        veiledProject.isTargetInstanceOf(Project),
+        true
+      );
+    }
+  );
 });


### PR DESCRIPTION
The `isTargetInstanceOf` method allows to check if the veiled object is the instance of a certain class or object it was created from.

It maybe helpful when we don't want to expose the state of the Veil object instance, such as a `#target` or `#targetProto` prop, but want some additional behavior like the JS native syntax does:
```JavaScript
class A { };
const a = new A();
a instanceOf A; // true
```

---

Usage:
```JavaScript
veiledProject.isTargetInstanceOf(project); // checking against the origin object
veiledProject.isTargetInstanceOf(Project); // checking agaist the origin class
```